### PR TITLE
(Added) Addition of PhpUnused annotations to methods in Trace.php

### DIFF
--- a/src/Trace.php
+++ b/src/Trace.php
@@ -35,6 +35,8 @@ final class Trace
      * Sets the directory where profile data files are stored.
      *
      * @param string $path The path to the directory.
+     *
+     * @noinspection PhpUnused
      */
     public static function setProfilesDir(string $path): void
     {
@@ -44,6 +46,8 @@ final class Trace
 
     /**
      * Enables XHProf profiling.
+     *
+     * @noinspection PhpUnused
      */
     public static function enableXhprof(): void
     {
@@ -55,6 +59,8 @@ final class Trace
      * Disables XHProf profiling and saves the profiling data to a file.
      *
      * @throws JsonException If an error occurs during JSON encoding.
+     *
+     * @noinspection PhpUnused
      */
     public static function disableXhprof(): void
     {
@@ -67,6 +73,8 @@ final class Trace
      * Generates a report from the profiling data and displays it in the console.
      *
      * @throws JsonException If an error occurs during JSON decoding.
+     *
+     * @noinspection PhpUnused
      */
     public static function displayReportCLI(): void
     {


### PR DESCRIPTION
## **User description**
## Summary

This Merge Request introduces `@noinspection PhpUnused` annotations to various methods within the `Trace.php` file. These annotations suppress IDE warnings concerning seemingly unused methods, which could be misleading during development. These methods, while appearing unused within the current file scope, may be invoked externally or required for future development phases.

### Context and Background

During development, IDEs like PhpStorm often flag unused methods, potentially leading to unintentional removal or overlooking of essential code. The addition of `@noinspection PhpUnused` annotations directly addresses this by clarifying the intended use and importance of these methods within the project’s broader scope.

### Problem Description

The issue was the IDE (PhpStorm) generating warnings for methods in `Trace.php` that seemed unused. This situation posed a risk of misleading developers, possibly resulting in the accidental removal of critical functionality or hindering future development efforts.

### Solution Description

The solution implemented involves adding `@noinspection PhpUnused` annotations to the `setProfilesDir`, `enableXhprof`, `disableXhprof`, and `displayReportCLI` methods. This approach effectively suppresses unwarranted IDE warnings, safeguarding against potential misunderstandings regarding the methods' usage and significance.

### List of Changes

- **Added**: Annotations `@noinspection PhpUnused` to suppress IDE warnings for the following methods in `src/Trace.php`:
  - `setProfilesDir(string $path): void`
  - `enableXhprof(): void`
  - `disableXhprof(): void`
  - `displayReportCLI(): void`


___

## **Type**
enhancement


___

## **Description**
- Added `@noinspection PhpUnused` annotations to several methods in `Trace.php` to suppress PhpStorm warnings about unused methods.
- These annotations clarify that methods such as `setProfilesDir`, `enableXhprof`, `disableXhprof`, and `displayReportCLI` might be used externally or in future development, despite appearing unused within the current file scope.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Trace.php</strong><dd><code>Suppress IDE Warnings for Unused Methods in Trace.php</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/Trace.php

<li>Added <code>@noinspection PhpUnused</code> annotations to suppress IDE warnings for <br>seemingly unused methods.<br> <li> Affected methods include <code>setProfilesDir</code>, <code>enableXhprof</code>, <code>disableXhprof</code>, <br>and <code>displayReportCLI</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/MarjovanLier/XhprofTrace/pull/8/files#diff-15329b36f4764bd79867bdc947704d9b2afcb82fd7627bd305ae5865be6fb833">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

