### PR TITLE
(Changed) Refactor of localTest.sh to Improve Error Handling and Test Coverage

### DIFF
--- a/docker/Dockerfile81
+++ b/docker/Dockerfile81
@@ -1,14 +1,18 @@
 FROM php:8.1-cli
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN set -eux; apt-get update && apt-get install -y \
         git \
         zip \
         libzip-dev \
+        && pecl install ast \
+        && pecl install xdebug \
         && pecl install xhprof \
-        && docker-php-ext-enable xhprof \
+        && docker-php-ext-install pdo pdo_mysql \
+        && docker-php-ext-enable ast pdo pdo_mysql xdebug xhprof \
         && docker-php-ext-install zip \
-        && rm -rf /var/lib/apt/lists/*
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /tmp/pear ~/.pearrc
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/docker/Dockerfile82
+++ b/docker/Dockerfile82
@@ -1,14 +1,18 @@
 FROM php:8.2-cli
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN set -eux; apt-get update && apt-get install -y \
         git \
         zip \
         libzip-dev \
+        && pecl install ast \
+        && pecl install xdebug \
         && pecl install xhprof \
-        && docker-php-ext-enable xhprof \
+        && docker-php-ext-install pdo pdo_mysql \
+        && docker-php-ext-enable ast pdo pdo_mysql xdebug xhprof \
         && docker-php-ext-install zip \
-        && rm -rf /var/lib/apt/lists/*
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /tmp/pear ~/.pearrc
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/docker/Dockerfile83
+++ b/docker/Dockerfile83
@@ -1,14 +1,18 @@
 FROM php:8.3-cli
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN set -eux; apt-get update && apt-get install -y \
         git \
         zip \
         libzip-dev \
+        && pecl install ast \
+        && pecl install xdebug \
         && pecl install xhprof \
-        && docker-php-ext-enable xhprof \
+        && docker-php-ext-install pdo pdo_mysql \
+        && docker-php-ext-enable ast pdo pdo_mysql xdebug xhprof \
         && docker-php-ext-install zip \
-        && rm -rf /var/lib/apt/lists/*
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /tmp/pear ~/.pearrc
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/localTest.sh
+++ b/localTest.sh
@@ -2,23 +2,44 @@
 
 set -euo pipefail
 
-
-docker build -t php-xprof-trace-composer-81 -f docker/Dockerfile81 .
-docker build -t php-xprof-trace-composer-82 -f docker/Dockerfile82 .
-docker build -t php-xprof-trace-composer-83 -f docker/Dockerfile83 .
-
 mkdir -p "$HOME"/.composer/docker-cache
 
-for version in 81 82 83; do
-  DOCKER_CMD="docker run -it --rm -v $(pwd):/var/www -v $HOME/.composer/docker-cache:/root/.composer php-xprof-trace-composer-$version"
-  rm -f composer.lock && \
-  $DOCKER_CMD composer --version && \
-  $DOCKER_CMD composer install && \
-  $DOCKER_CMD composer test:vulnerabilities-check && \
-  $DOCKER_CMD composer test:lint && \
-  $DOCKER_CMD composer test:code-style && \
-  $DOCKER_CMD composer test:phpmd && \
-  $DOCKER_CMD composer test:phpunit
+# Loop through PHP versions to build Docker images and run Composer commands
+for version in {81..83}; do
+  # Build Docker image for the current PHP version
+  IMAGE_NAME="php-xprof-trace-composer-$version"
+  docker build -t $IMAGE_NAME -f docker/Dockerfile"$version" .
+  if [ $? -ne 0 ]; then
+    echo "Docker build failed for PHP version $version"
+    exit 1
+  fi
+
+  # Define Docker run command
+  DOCKER_CMD="docker run -it --rm -v $(pwd):/var/www -v $HOME/.composer/docker-cache:/root/.composer $IMAGE_NAME"
+  $DOCKER_CMD composer --version
+  $DOCKER_CMD composer update && exit 1
+
+  # Remove existing composer.lock, display Composer version, and run Composer install and update for PHP 8.1
+  if [ "$version" -eq 81 ]; then
+    rm -f composer.lock && \
+    $DOCKER_CMD composer install && \
+    $DOCKER_CMD composer update --with-all-dependencies && \
+    $DOCKER_CMD composer require --dev --with-all-dependencies rector/rector
+
+    # Check for errors immediately after Composer commands
+    if [ $? -ne 0 ]; then
+        echo "Composer install failed for PHP $version"
+        exit 1
+    fi
+  fi
+
+  $DOCKER_CMD composer tests
+
+  # If any of the above commands fail, the script will stop and exit with a non-zero status code.
+  if [ $? -ne 0 ]; then
+    echo "Tests failed for PHP $version"
+    exit 1
+  fi
 done
 
 echo "All tests passed successfully!"

--- a/localTest.sh
+++ b/localTest.sh
@@ -17,7 +17,6 @@ for version in {81..83}; do
   # Define Docker run command
   DOCKER_CMD="docker run -it --rm -v $(pwd):/var/www -v $HOME/.composer/docker-cache:/root/.composer $IMAGE_NAME"
   $DOCKER_CMD composer --version
-  $DOCKER_CMD composer update && exit 1
 
   # Remove existing composer.lock, display Composer version, and run Composer install and update for PHP 8.1
   if [ "$version" -eq 81 ]; then

--- a/localTest.sh
+++ b/localTest.sh
@@ -8,7 +8,7 @@ mkdir -p "$HOME"/.composer/docker-cache
 for version in {81..83}; do
   # Build Docker image for the current PHP version
   IMAGE_NAME="php-xprof-trace-composer-$version"
-  docker build -t $IMAGE_NAME -f docker/Dockerfile"$version" .
+  docker build -t "$IMAGE_NAME" -f "docker/Dockerfile$version" .
   if [ $? -ne 0 ]; then
     echo "Docker build failed for PHP version $version"
     exit 1


### PR DESCRIPTION
## **User description**
## Summary

This merge request refactors the `localTest.sh` script to enhance error handling and expand test coverage across multiple PHP versions. The primary changes include building Docker images and running Composer commands in a loop for PHP versions 8.1, 8.2, and 8.3. Additionally, error handling has been improved by exiting the script with a non-zero status code upon encountering failures during the Docker build, Composer installation, or test execution process.

### Context and Background

The `localTest.sh` script is crucial to the project's local testing and development workflow. It automates building Docker images and running various Composer commands, including installing dependencies, checking for vulnerabilities, linting code, and executing unit tests. As the project continues to evolve and support multiple PHP versions, ensuring that the testing process is robust, reliable, and provides comprehensive coverage across all supported versions becomes essential.

### Problem Description

The previous version of the `localTest.sh` script lacked proper error handling and did not effectively handle failures during the Docker build or Composer command execution. Additionally, the script only executed tests for the latest PHP version, leaving potential compatibility issues with other supported versions undetected.

### Solution Description

The refactored `localTest.sh` script addresses these issues by introducing a loop that iterates through the PHP versions 8.1, 8.2, and 8.3. For each version, the script performs the following actions:

1. Build a Docker image specific to the current PHP version.
2. Define a Docker run command that mounts the project directory and Composer cache.
3. Execute various Composer commands, including version check, update, and tests.

Furthermore, the script now includes error handling mechanisms that exit with a non-zero status code upon encountering any failures during the Docker build, Composer installation, or test execution processes. This approach ensures that issues are promptly identified and addressed, preventing the script from continuing with subsequent steps when a critical failure occurs.

For PHP 8.1, additional steps have been added to remove the existing `composer.lock` file, install dependencies, update dependencies with all dependencies, and require the `rector/rector` package as a dev dependency.

### List of Changes

- **Changed**:
  - `localTest.sh` - Refactored the script to run tests for multiple PHP versions (8.1, 8.2, 8.3) in a loop.
  - `localTest.sh` - Improved error handling by exiting with a non-zero status code upon encountering failures during Docker build, Composer installation, or test execution.
- **Added**:
  - `localTest.sh` - Additional steps for PHP 8.1 to remove `composer.lock`, install dependencies with all dependencies, and require `rector/rector` as a dev dependency.


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Refactored `localTest.sh` to enhance error handling and support multiple PHP versions (8.1, 8.2, 8.3).
- Introduced a loop mechanism to build Docker images and run Composer commands for each PHP version, improving test coverage.
- Added comprehensive error handling to exit the script with a non-zero status code upon encountering any failures, enhancing reliability.
- Specifically for PHP 8.1, added steps to handle `composer.lock`, update dependencies, and include `rector/rector` as a dev dependency, addressing potential compatibility issues.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>localTest.sh</strong><dd><code>Refactor Script for Enhanced Error Handling and PHP Version Coverage</code></dd></summary>
<hr>
      
localTest.sh

<li>Introduced a loop to build Docker images and run Composer commands for <br>PHP versions 8.1, 8.2, and 8.3.<br> <li> Added error handling to exit with a non-zero status code upon <br>encountering failures during Docker build, Composer installation, or <br>test execution.<br> <li> For PHP 8.1, added steps to remove <code>composer.lock</code>, install and update <br>dependencies, and require <code>rector/rector</code> as a dev dependency.<br> <li> Improved the script's readability and maintainability by restructuring <br>commands and checks.


</details>
    

  </td>
  <td><a href="https://github.com/MarjovanLier/XhprofTrace/pull/19/files#diff-ee3cef051df5421a0c1f313c0666b6c8c80b8ec26be919fdfe65992736b6091a">+35/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the testing script to support dynamic PHP version testing from 8.1 to 8.3, including improved error handling and version-specific Composer command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->